### PR TITLE
Strip extra characters that broke Recov extraction.

### DIFF
--- a/scripts/readwritematvec.sh
+++ b/scripts/readwritematvec.sh
@@ -47,6 +47,9 @@ awkcmd2='BEGIN{FS=","}
     printf("\n");}'
 gawk "$awkcmd1" $1|gawk "$awkcmd2" > .RECOV.mtx
 
+tr -d $'\r' < .RECOV.mtx > .RECOV_ALT.mtx
+mv .RECOV_ALT.mtx .RECOV.mtx
+
 echo "Preprocessing mtx files done"
 
 python3 <<EOF


### PR DESCRIPTION
Needed when Abaqus was run on Windows and this script on WSL. Not sure if this is the exact form of the desired fix. 


Example output from Abaqus (4 requested nodes):
```
** RECOVERY MATRIX OF SUBSTRUCTURE Z1      
** NUMBER OF INTERNAL NODES =          4
** INTERNAL NODES:
**      13618,      13658,      41185,      41254
          1,          2,          3
** SUBSTRUCTURE RECOVERY VECTOR CORRESPONDING TO RETAINED DOFS NUMBER        1
**  0.24911774683605E-06, 0.36030596868123E-08, 0.74766717757092E-05, 0.23797570908241E-06,
**  0.20464393072890E-08, 0.40917257483274E-05, 0.10455050758132E-07, 0.11369764940622E-07,
**  -.80546914370596E-06, 0.11352056035013E-07, 0.32267911394212E-07, -.23738093454889E-05
** SUBSTRUCTURE RECOVERY VECTOR CORRESPONDING TO RETAINED DOFS NUMBER        2
**  -.56956204717640E-09, -.75911251304955E-05, -.13673260957576E-07, -.59482262649898E-09,
**  -.42898386203332E-05, -.74368828209088E-08, -.27385141516951E-09, -.11579671575795E-05,
**  0.18540237103197E-07, -.29199543945853E-09, -.25239621983254E-05, 0.53710082692167E-07
** SUBSTRUCTURE RECOVERY VECTOR CORRESPONDING TO RETAINED DOFS NUMBER        3
**  0.28929052470250E-05, 0.13788824649762E-07, 0.94523891549780E-04, 0.28289896958933E-05,
**  0.79481309946866E-08, 0.51725511846427E-04, 0.47374478621256E-07, -.45906862602502E-08,
**  -.23156448569582E-05, 0.49557163073206E-07, -.12360733919532E-07, -.66806135517113E-05
** SUBSTRUCTURE RECOVERY VECTOR CORRESPONDING TO RETAINED DOFS NUMBER        4
```

.RECOV.mtx had several ^M characters applied at the end of every line that appeared in the base mtx file (e.g., between all 4 x entries and all 4 y entries). While these were not read as new line characters in vim/less, the python read and save output a matrix of size 4x(3*Ndof). Where Ndof is the reduced number of degrees of freedom. 

I believe the resulting output should now be in the form of a matrix with rows: [N1x; N2x; N3x; N4x; N1y; N2y; N3y; N4y; N1z; N2z; N3z; N4z]. This should probably be made clear in the tutorial as well: [here](https://nidish96.github.io/Abaqus4Joints/#outline-container-sec:mex)